### PR TITLE
test: enable dpdk initialization before running validation on linux-dpdk

### DIFF
--- a/platform/linux-generic/test/wrapper-script.sh
+++ b/platform/linux-generic/test/wrapper-script.sh
@@ -1,0 +1,3 @@
+#wrapper script for pre setting environment for validation suit.
+#currently this is empty but needs to be created to make it align with
+#linux-dpdk.

--- a/test/Makefile.inc
+++ b/test/Makefile.inc
@@ -20,6 +20,8 @@ AM_CFLAGS = $(CUNIT_CFLAGS)
 
 AM_LDFLAGS = -L$(LIB) -static
 
+LOG_COMPILER = $(top_srcdir)/platform/@with_platform@/test/wrapper-script.sh
+
 @VALGRIND_CHECK_RULES@
 
 TESTS_ENVIRONMENT = ODP_PLATFORM=${with_platform} \

--- a/test/performance/Makefile.am
+++ b/test/performance/Makefile.am
@@ -31,6 +31,6 @@ odp_sched_latency_SOURCES = odp_sched_latency.c
 odp_scheduling_SOURCES = odp_scheduling.c
 odp_pktio_perf_SOURCES = odp_pktio_perf.c
 
-dist_check_SCRIPTS = $(TESTSCRIPTS)
+dist_check_SCRIPTS = $(TESTSCRIPTS) $(LOG_COMPILER)
 
 dist_check_DATA = udp64.pcap


### PR DESCRIPTION
Signed-off-by: Balakrishna Garapati <balakrishna.garapati@linaro.org>